### PR TITLE
Fix: Elapsed time bugs and loop_count input bug

### DIFF
--- a/image_generator.py
+++ b/image_generator.py
@@ -7,7 +7,6 @@ import time
 
 
 def main_loop():
-    start_time = time.time()
 
     # Make the NFT/ dir 
     PATH = makeNFTsDir()
@@ -19,9 +18,15 @@ def main_loop():
     while True:
         try:
             loop_counter = int(input('How many images would you like to generate?: '))
-            break
+            if loop_counter < 1:  # User entered value less than 1
+                print("Number of images must be at least 1.")
+            else:  # Value is an integer and greater than or equal to 1
+                break
         except ValueError:
-            print('wrong input...')
+            print('Wrong input...')
+
+    # Start time for counting elapsed image generation time
+    start_time = time.time()
 
     # turns image_data file into a list
     file = open('image_data.txt', 'r')
@@ -339,7 +344,8 @@ def main_loop():
 
     rarity()
     
-    print("Process finished --- %s seconds ---" % (time.time() - start_time))
+    # Prints elapsed time to generate images rounded to 2 decimal places
+    print(f"Process finished --- {round(time.time()-start_time, 2)}s seconds ---")
     rarity_display(rarity_array)
 
 


### PR DESCRIPTION
1. Fix: Program would formerly print total elapsed time *including* time it takes for user to enter num. of images to generate. E.g. if the user takes 10 seconds to enter num of images to generate, 10 seconds would be added to the supposed time to process N number of images.

2. Fix: If user entered a value less than 1 (e.g. 0, -2 etc.) program would crash. Program now catches this error and asks user to try another value.

3. Fix: Program will now round image processing time to 2 decimal places. This can be changed by just changing the 2nd argument passed into the round() function when printing output. Makes the output cleaner by not displaying hella decimals to stdout.